### PR TITLE
add name to the reserved names, because you cant assign to function.n…

### DIFF
--- a/src/compile.js
+++ b/src/compile.js
@@ -221,7 +221,8 @@ var reservedNames_ = {
     "unwatch": true,
     "valueOf": true,
     "watch": true,
-    "length": true
+    "length": true,
+    "name": true,
 };
 
 function fixReservedNames (name) {


### PR DESCRIPTION
…ame, even though it sometimes is allowed

So sometimes it throws an error, but not in every situation. But it never succeeds to assign to `name` so I've added it to the reserved names.