### PR TITLE
worked around inheritance problem

### DIFF
--- a/src/object.js
+++ b/src/object.js
@@ -13,20 +13,13 @@ Sk.builtin.object = function () {
         return new Sk.builtin.object();
     }
 
-    var __init__ = function __init__() {
-        return Sk.builtin.none.none$;
-    };
-
-    __init__.co_kwargs = 1;
-
-    this["$d"] = {
-        __init__: __init__
-    };
-
     return this;
 };
 
-
+Sk.builtin.object.prototype.__init__ = function __init__() {
+    return Sk.builtin.none.none$;
+};
+Sk.builtin.object.prototype.__init__.co_kwargs = 1;
 
 Sk.builtin._tryGetSubscript = function(dict, pyName) {
     try {

--- a/src/object.js
+++ b/src/object.js
@@ -13,13 +13,20 @@ Sk.builtin.object = function () {
         return new Sk.builtin.object();
     }
 
+    var __init__ = function __init__() {
+        return Sk.builtin.none.none$;
+    };
+
+    __init__.co_kwargs = 1;
+
+    this["$d"] = {
+        __init__: __init__
+    };
+
     return this;
 };
 
-Sk.builtin.object.prototype.__init__ = function __init__() {
-    return Sk.builtin.none.none$;
-};
-Sk.builtin.object.prototype.__init__.co_kwargs = 1;
+
 
 Sk.builtin._tryGetSubscript = function(dict, pyName) {
     try {

--- a/src/type.js
+++ b/src/type.js
@@ -567,7 +567,7 @@ Sk.builtin.type.typeLookup = function (type, pyName) {
         if (res !== undefined) {
             return res;
         }
-        if (base.prototype && base.prototype[jsName] !== undefined) {
+        if (base.prototype && base.prototype.hasOwnProperty(jsName)) {
             return base.prototype[jsName];
         }
     }


### PR DESCRIPTION
the inheritance problem persists, because when we inherit from an object
we copy over the prototype of the base object, and because the prototype
of object contained `__init__` we found that before we found `__init__`
in the dict of the base object. mro looks in the prototype of an object
when doing a typelookup.

To mitigate it I moved the `__init__` of object to the `$d` dict. It
solves the problem, but it doesn't solve the larger problem. We will
have to revisit this, to maybe not have the mro look in the prototype or
maybe to not copy python functions from the parent object.

Also the `test_set.py` tests still fail for different reasons now. 😕 